### PR TITLE
feat(dynamic-key): Eliminates FOUC while allowing a user defined `localStorageKey`

### DIFF
--- a/package/src/foucKillerScript.ts
+++ b/package/src/foucKillerScript.ts
@@ -1,0 +1,15 @@
+import { localStorageKey } from "virtual:astro-fouc-killer/config";
+
+const preferredTheme =
+  localStorage.getItem(localStorageKey) ||
+  (window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light");
+
+document.documentElement.classList.toggle("dark", preferredTheme === "dark");
+
+window.addEventListener("storage", () => {
+  const isDark = localStorage.getItem(localStorageKey) === "dark";
+  document.documentElement.classList.toggle("dark", isDark);
+});
+ 

--- a/package/src/foucKillerScript.ts
+++ b/package/src/foucKillerScript.ts
@@ -1,15 +1,6 @@
 import { localStorageKey } from "virtual:astro-fouc-killer/config";
 
-const preferredTheme =
-  localStorage.getItem(localStorageKey) ||
-  (window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light");
-
-document.documentElement.classList.toggle("dark", preferredTheme === "dark");
-
 window.addEventListener("storage", () => {
   const isDark = localStorage.getItem(localStorageKey) === "dark";
   document.documentElement.classList.toggle("dark", isDark);
 });
- 

--- a/package/tsup.config.ts
+++ b/package/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig((options) => {
 		clean: true,
 		splitting: false,
 		minify: !dev,
-		external: [...Object.keys(peerDependencies)],
+		external: ['virtual:astro-fouc-killer/config', ...Object.keys(peerDependencies)],
 		tsconfig: "tsconfig.json",
 	};
 });

--- a/package/virtual.d.ts
+++ b/package/virtual.d.ts
@@ -1,0 +1,8 @@
+declare module "virtual:astro-fouc-killer/config" {
+  export const localStorageKey: string;
+}
+
+// declare module "virtual:astro-fouc-killer/script" {
+//   const script: void;
+//   export default script;
+// }

--- a/playground/astro.config.mts
+++ b/playground/astro.config.mts
@@ -9,7 +9,7 @@ import astroFoucKiller from "astro-fouc-killer";
 export default defineConfig({
   integrations: [
     tailwind(),
-    astroFoucKiller(),
+    astroFoucKiller({localStorageKey: "theme-test"}),
     hmrIntegration({
       directory: createResolver(import.meta.url).resolve("../package/dist"),
     }),


### PR DESCRIPTION
### [(dd50c46)](https://github.com/AVGVSTVS96/astro-fouc-killer/commit/dd50c4652a58d4ed5751d76cfbd1b5cd9334fb4c) fix(dynamic-key): Eliminates FOUC while allowing a user defined `localStorageKey`

This fix eliminates FOUC while allowing a user defined localStorageKey

This implementaions splits the script into two parts: an inline script and a processed script.

The inline script is defined directly within the injectScript function using head-inline and is a simple script that gets the value of the user defined, or default, localStorageKey and sets the theme based on it.

The second part of the script uses the page stage so it can be defined in a different file and import the virtual config module. This way, it too can utilize the user defined, or default, localStorageKey values; It then listens for changes in local storage and toggles dark class accordingly.

chore(test-dynamic-key): Update playground astro.config.mts to test user defined localStorageKey value

### [(92c5cb2)]([https://github.com/AVGVSTVS96/astro-fouc-killer/commit/dd50c4652a58d4ed5751d76cfbd1b5cd9334fb4c](https://github.com/AVGVSTVS96/astro-fouc-killer/commit/92c5cb264487e4558a25afb0ab85b46f6f3f705b)) feat(dynamic-key): first proof of concept for user defined dynamic `localStorageKey` in injected script

This proof of concept injects the fouc killer script during the `page` stage of rendering. This means that fouc is not eliminated because the script is run after the initial CSS is loaded.

However, this proof of concept demonstrates using virtual modules to dynamically set a user defined `localStorageKey` by importing it into a script, which is then injected into every page.

The first working version of this integration injects a script with a static local storage key using `head-inline`, this ensures the script is run before the intiial CSS is loaded on the page.

However, `head-inline` scripts are not processed or resolved by Vite, so dynamically setting the `localStorageKey` is challenging.

In this proof of concept, the dynamic `localStorageKey` is set by importing a virtual config module with the user defined key into a separate `foucKillerScript` file. This file is then resolved with `createResolver` and passed to the `injectScript` to be injected as a processed and resolved module at the `page` stage, after the initial CSS is loaded. This is why this proof of concept does not eliminate fouc, `head-inline` scripts are not processed by Vite so `page` is the only stage that can be used for dynamic script injection.