### PR TITLE
fix(dynamic-key): Eliminates FOUC while allowing a user defined `localStorageKey`

### DIFF
--- a/package/src/foucKillerScript.ts
+++ b/package/src/foucKillerScript.ts
@@ -1,15 +1,6 @@
 import { localStorageKey } from "virtual:astro-fouc-killer/config";
 
-const preferredTheme =
-  localStorage.getItem(localStorageKey) ||
-  (window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light");
-
-document.documentElement.classList.toggle("dark", preferredTheme === "dark");
-
 window.addEventListener("storage", () => {
   const isDark = localStorage.getItem(localStorageKey) === "dark";
   document.documentElement.classList.toggle("dark", isDark);
 });
- 

--- a/playground/astro.config.mts
+++ b/playground/astro.config.mts
@@ -9,7 +9,7 @@ import astroFoucKiller from "astro-fouc-killer";
 export default defineConfig({
   integrations: [
     tailwind(),
-    astroFoucKiller(),
+    astroFoucKiller({localStorageKey: "theme-test"}),
     hmrIntegration({
       directory: createResolver(import.meta.url).resolve("../package/dist"),
     }),


### PR DESCRIPTION
This fix eliminates FOUC while allowing a user defined `localStorageKey`

---

This implementaions splits the script into two parts: an inline script and a processed script.

The inline script is defined directly within the `injectScript` function using `head-inline` and is a simple script that gets the value of the user defined, or default, `localStorageKey` and sets the theme based on it.

The second part of the script uses the `page` stage so it can be defined in a different file and import the virtual config module. This way, it too can utilize the user defined, or default, `localStorageKey` values; It then listens for changes in local storage and toggles dark class accordingly.

chore(test-dynamic-key): Update playground `astro.config.mts` to test user defined `localStorageKey` value