### PR TITLE
refactor: Minor updates to zod schema, biome and release config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,6 @@
     }
   },
   "files": {
-    "ignore": ["dist", ".astro"]
+    "ignore": ["dist", ".astro", "node_modules"]
   }
 }

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 285c4f9: Full functionality achieved
+- [dd50c46](https://github.com/AVGVSTVS96/astro-fouc-killer/commit/dd50c4652a58d4ed5751d76cfbd1b5cd9334fb4c): Full functionality achieved, user can define custom local storage key
 
 ## 0.3.0
 

--- a/package/src/integration.ts
+++ b/package/src/integration.ts
@@ -9,16 +9,16 @@ export const astroFoucKiller = defineIntegration({
   name: "astro-fouc-killer",
   optionsSchema: z
     .object({
-      localStorageKey: z.string(),
+      localStorageKey: z.string().default("themeToggle"),
     })
-    .optional(),
+    .default({}),
   setup({ name, options }) {
     return {
       hooks: {
         "astro:config:setup": (params) => {
           const { injectScript, logger } = params;
           const { resolve } = createResolver(import.meta.url);
-          const localStorageKey = options?.localStorageKey ?? "themeToggle";
+          const localStorageKey = options.localStorageKey;
 
           addVirtualImports(params, {
             name,
@@ -34,15 +34,17 @@ export const astroFoucKiller = defineIntegration({
           injectScript(
             "head-inline",
             `(function() {
-              var key = '${localStorageKey}';
+              var key = ${JSON.stringify(localStorageKey)};
               var preferredTheme = localStorage.getItem(key) || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
               document.documentElement.classList.toggle('dark', preferredTheme === 'dark');
             })();`
           );
-          logger.info("Astro Fouc Killer: Injected inline script");
 
           injectScript("page", `import "${resolve("./foucKillerScript")}";`);
-          logger.info("Astro Fouc Killer: Injected page script");
+
+          logger.info(
+            "Astro Fouc Killer: Successfully injected fouc killer scripts"
+          );
         },
       },
     };

--- a/package/src/integration.ts
+++ b/package/src/integration.ts
@@ -43,7 +43,7 @@ export const astroFoucKiller = defineIntegration({
           injectScript("page", `import "${resolve("./foucKillerScript")}";`);
 
           logger.info(
-            "Astro Fouc Killer: Successfully injected fouc killer scripts"
+            "Successfully injected fouc killer scripts"
           );
         },
       },

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -44,7 +44,7 @@ const main = async () => {
   await run("git push --follow-tags");
   const tag = (await run("git describe --abbrev=0")).replace("\n", "");
   await run(
-    `gh release create ${tag} --title ${tag} --notes "Please refer to [CHANGELOG.md](https://github.com/AVGVSTVS96/astro-fouc-killer/blob/main/CHANGELOG.md) for details."`
+    `gh release create ${tag} --title ${tag} --notes "Please refer to [CHANGELOG.md](https://github.com/AVGVSTVS96/astro-fouc-killer/blob/main/package/CHANGELOG.md) for details."`
   );
 };
 


### PR DESCRIPTION
- refactor(default-key): Define default key in zod schema
  - This replaces using the nullish coalescing operator to return the default key if its not provided by the user

* chore(biome): Ignore `node_modules`
- fix(release): Correct changelog path when creating github release